### PR TITLE
xml widgets need resource id's for RMQ wrap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bluepotion (0.0.5)
+    bluepotion (0.0.6)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/project/pro_motion/pm_screen.rb
+++ b/lib/project/pro_motion/pm_screen.rb
@@ -53,7 +53,8 @@
     def setup_xml_widgets
       return unless (xml_widget_ids = self.class.xml_widget_ids)
       xml_widget_ids.each do |id|
-        instance_variable_set("@#{id.to_s}".to_sym, find(id))
+        resource_id = resources.getIdentifier(id.to_s, "id", activity.getApplicationInfo.packageName)
+        instance_variable_set("@#{id.to_s}".to_sym, find(resource_id))
       end
     end
 


### PR DESCRIPTION
Each id in XML is a string, when RMQ wanted a resource.   I fixed the `setup_xml_widgets` to work with that conversion.

Ideally, RMQ find could try to look into the XML rather than returning 0 results.  Let's discuss.