### PR TITLE
Added very basic close method to screens

### DIFF
--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -125,6 +125,10 @@
       self.activity.startActivity intent
     end
 
+    def close(options={})
+      self.activity.finish
+    end
+
     def start_activity(activity_class)
       intent = Android::Content::Intent.new(self.activity, activity_class)
       #intent.putExtra("key", value); # Optional parameters


### PR DESCRIPTION
We'll need to do some `on_return` goodness, probably. And since we're a fragment, closing the whole activity might not be desirable. But it does work.