### PR TITLE
Renamed uses_xml and uses_action_bar to layout and nav_bar

### DIFF
--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -18,10 +18,10 @@
         @rmq_style_sheet_class
       end
 
-      def layout(xml_resource=nil)
+      def xml_layout(xml_resource=nil)
         @xml_resource = xml_resource ||= deduce_resource_id
       end
-      alias_method :uses_xml, :layout
+      alias_method :uses_xml, :xml_layout
 
       def action_bar(show_action_bar)
         @show_action_bar = show_action_bar

--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -18,13 +18,16 @@
         @rmq_style_sheet_class
       end
 
-      def uses_xml(xml_resource=nil)
+      def layout(xml_resource=nil)
         @xml_resource = xml_resource ||= deduce_resource_id
       end
+      alias_method :uses_xml, :layout
 
-      def uses_action_bar(show_action_bar)
+      def action_bar(show_action_bar)
         @show_action_bar = show_action_bar
       end
+      alias_method :nav_bar, :action_bar
+      alias_method :uses_action_bar, :action_bar
 
       def title(new_title)
         @bars_title = new_title


### PR DESCRIPTION
I added aliases so older code doesn't break, but I like this better. I think I'll be introducing the `nav_bar` one into ProMotion iOS. Related: https://github.com/clearsightstudio/ProMotion/issues/631#issuecomment-105079694

![screen shot 2015-06-02 at 2 51 59 pm](https://cloud.githubusercontent.com/assets/1479215/7948189/f19b3f8a-0936-11e5-9463-5b5bc5e5e345.png)