### PR TITLE
Added lifecycle methods, set_action_bar_button

### DIFF
--- a/lib/project/pro_motion/pm_activity.rb
+++ b/lib/project/pro_motion/pm_activity.rb
@@ -36,7 +36,6 @@
     def onCreateOptionsMenu(menu)
       on_create_menu(menu)
     end
-
     def on_create_menu(_); end
 
   end

--- a/lib/project/pro_motion/pm_activity.rb
+++ b/lib/project/pro_motion/pm_activity.rb
@@ -33,6 +33,12 @@
     def clear_references
     end
 
+    def onCreateOptionsMenu(menu)
+      on_create_menu(menu)
+    end
+
+    def on_create_menu(_); end
+
   end
 
 #end

--- a/lib/project/pro_motion/pm_screen.rb
+++ b/lib/project/pro_motion/pm_screen.rb
@@ -65,6 +65,8 @@
     def onResume; super; on_resume; end
     def on_resume; end
 
+    def on_create_menu(menu); end
+
     def onPause; super; on_pause; end
     def on_pause; end
 

--- a/lib/project/pro_motion/pm_screen.rb
+++ b/lib/project/pro_motion/pm_screen.rb
@@ -6,6 +6,12 @@
 
     attr_accessor :view
 
+    def onAttach(activity); super; on_attach(activity); end
+    def on_attach(activity); end
+
+    def onCreate(bundle); super; on_create(bundle); end
+    def on_create(bundle); end
+
     def onCreateView(inflater, parent, saved_instance_state)
       super
 
@@ -18,8 +24,11 @@
 
       action_bar.hide if hide_action_bar?
 
+      on_create_view(inflater, parent, saved_instance_state)
+
       @view
     end
+    def on_create_view(inflater, parent, saved_instance_state); end
 
     def load_view
       Potion::FrameLayout.new(self.activity)
@@ -45,8 +54,31 @@
       self.activity.title = self.class.bars_title
 
       on_load
+      on_activity_created
     end
+    def on_load; end
+    def on_activity_created; end
 
+    def onStart; super; on_start; end
+    def on_start; end
+
+    def onResume; super; on_resume; end
+    def on_resume; end
+
+    def onPause; super; on_pause; end
+    def on_pause; end
+
+    def onStop; super; on_stop; end
+    def on_stop; end
+
+    def onDestroyView; super; on_destroy_view; end
+    def on_destroy_view; end
+
+    def onDestroy; super; on_destroy; end
+    def on_destroy; end
+
+    def onDetach; super; on_detach; end
+    def on_detach; end
 
     private
 

--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -154,5 +154,37 @@
       activity.getActionBar()
     end
 
+    def menu
+      activity.menu
+    end
+
+    # Example: set_action_bar_button :right, { title: "My text", show: :if_room }
+    def set_action_bar_button(side, options={})
+      unless menu
+        mp "#{self.inspect}#set_action_bar_button: No menu set up yet."
+        return
+      end
+
+      option[:show] ||= :always
+
+      # Should be something like Android::MenuItem::SHOW_AS_ACTION_IF_ROOM
+      show_as_action = 0 if options[:show] == :never
+      show_as_action = 1 if options[:show] == :if_room
+      show_as_action = 2 if options[:show] == :always
+      show_as_action = 4 if options[:show] == :with_text
+      show_as_action = 8 if options[:show] == :collapse
+
+      if side == :left
+        mp "#{self.inspect}#set_action_bar_button: Left bar buttons not implemented yet."
+      elsif side == :right
+        btn = self.activity.menu.add(options.fetch(:group, 0), options.fetch(:item_id, 0), options.fetch(:order, 0), options.fetch(:title, "Untitled"))
+        btn.setShowAsAction(show_as_action) if show_as_action
+        btn.setIcon(options[:icon]) if options[:icon]
+      end
+      btn
+    end
+    alias_method :set_nav_bar_button, :set_action_bar_button
+
+
   end
 #end

--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -165,7 +165,7 @@
         return
       end
 
-      option[:show] ||= :always
+      options[:show] ||= :always
 
       # Should be something like Android::MenuItem::SHOW_AS_ACTION_IF_ROOM
       show_as_action = 0 if options[:show] == :never

--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -158,8 +158,8 @@
       activity.menu
     end
 
-    # Example: set_action_bar_button :right, { title: "My text", show: :if_room }
-    def set_action_bar_button(side, options={})
+    # Example: add_action_bar_button(title: "My text", show: :if_room)
+    def add_action_bar_button(options={})
       unless menu
         mp "#{self.inspect}#set_action_bar_button: No menu set up yet."
         return
@@ -174,17 +174,11 @@
       show_as_action = 4 if options[:show] == :with_text
       show_as_action = 8 if options[:show] == :collapse
 
-      if side == :left
-        mp "#{self.inspect}#set_action_bar_button: Left bar buttons not implemented yet."
-      elsif side == :right
-        btn = self.activity.menu.add(options.fetch(:group, 0), options.fetch(:item_id, 0), options.fetch(:order, 0), options.fetch(:title, "Untitled"))
-        btn.setShowAsAction(show_as_action) if show_as_action
-        btn.setIcon(options[:icon]) if options[:icon]
-      end
+      btn = self.activity.menu.add(options.fetch(:group, 0), options.fetch(:item_id, 0), options.fetch(:order, 0), options.fetch(:title, "Untitled"))
+      btn.setShowAsAction(show_as_action) if show_as_action
+      btn.setIcon(options[:icon]) if options[:icon]
       btn
     end
-    alias_method :set_nav_bar_button, :set_action_bar_button
-
 
   end
 #end

--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -161,7 +161,7 @@
     # Example: add_action_bar_button(title: "My text", show: :if_room)
     def add_action_bar_button(options={})
       unless menu
-        mp "#{self.inspect}#set_action_bar_button: No menu set up yet."
+        mp "#{self.inspect}#add_action_bar_button: No menu set up yet."
         return
       end
 

--- a/lib/project/pro_motion/pm_single_fragment_activity.rb
+++ b/lib/project/pro_motion/pm_single_fragment_activity.rb
@@ -2,7 +2,7 @@
 # RM-733
 #module ProMotion
   class PMSingleFragmentActivity < PMActivity
-    attr_accessor :fragment_container, :fragment
+    attr_accessor :fragment_container, :fragment, :menu
 
     EXTRA_FRAGMENT_CLASS = "fragment_class"
 
@@ -25,6 +25,10 @@
       mp "PMSingleFragmentActivity set_fragment", debugging_only: true
       @fragment = fragment # useful for the REPL
       fragmentManager.beginTransaction.add(@fragment_container.getId, fragment, fragment.class.to_s).commit
+    end
+
+    def on_create_menu(menu)
+      @menu = menu
     end
 
   end

--- a/lib/project/pro_motion/pm_single_fragment_activity.rb
+++ b/lib/project/pro_motion/pm_single_fragment_activity.rb
@@ -29,6 +29,7 @@
 
     def on_create_menu(menu)
       @menu = menu
+      self.fragment.on_create_menu(menu) if self.fragment
     end
 
   end


### PR DESCRIPTION
Added `on_attach`, `on_create`, `on_create_view`, `on_activity_created` (same as `on_load`), `on_start`, `on_resume`, `on_pause`, `on_stop`, `on_destroy_view`, `on_destroy`, `on_detach`.

Also added a preliminary version of `add_action_bar_button`. It's pretty rough, needs work, but does create a button.