### PR TITLE
Add more events

### DIFF
--- a/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_click.rb
+++ b/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_click.rb
@@ -1,0 +1,23 @@
+class RMQClickBase
+  attr_accessor :click_block
+
+  def initialize(&block)
+    @click_block = block
+  end
+end
+
+class RMQClick < RMQClickBase
+
+  def onClick(view)
+    click_block.call(view)
+  end
+
+end
+
+class RMQItemClick < RMQClickBase
+
+  def onItemClick(parent, view, position, id)
+    click_block.call(parent, view, position, id)
+  end
+
+end

--- a/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_seek_change.rb
+++ b/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_seek_change.rb
@@ -1,0 +1,24 @@
+class RMQSeekChange
+  attr_accessor :change_block
+
+  def initialize(action=:change, &block)
+    # Empty hash from RMQ Events means we keep our default
+    action = :change if action == {}
+
+    @action = action
+    @change_block = block
+  end
+
+  def onStopTrackingTouch(seek_bar)
+    @change_block.call(seek_bar) if @action == :stop
+  end
+
+  def onStartTrackingTouch(seek_bar)
+    @change_block.call(seek_bar) if @action == :start
+  end
+
+  def onProgressChanged(seek_bar, progress, from_user)
+    @change_block.call(seek_bar, progress, from_user) if @action == :change
+  end
+
+end

--- a/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_seek_change.rb
+++ b/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_seek_change.rb
@@ -2,10 +2,9 @@ class RMQSeekChange
   attr_accessor :change_block
 
   def initialize(action=:change, &block)
-    # Empty hash from RMQ Events means we keep our default
-    action = :change if action == {}
-
     @action = action
+    # Empty hash from RMQ Events means we keep our default
+    @action = :change if @action == {}
     @change_block = block
   end
 

--- a/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_text_change.rb
+++ b/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_text_change.rb
@@ -1,0 +1,24 @@
+# http://developer.android.com/reference/android/text/TextWatcher.html
+# there seems to be a bug with this particular interface - subclassing this class works around it
+# http://community.rubymotion.com/t/how-to-use-textwatcher-to-listen-to-changes-of-an-edittext/522
+class RMQTextChange < Android::Telephony::PhoneNumberFormattingTextWatcher
+  attr_accessor :change_block
+
+  def initialize(action=:after, &block)
+    @action = action
+    @change_block = block
+  end
+
+  def onTextChanged(s, start, before, count)
+    @change_block.call(s, start, before, count) if @action == :on
+  end
+
+  def beforeTextChanged(s, start, count, after)
+    @change_block.call(s, start, count, after) if @action == :before
+  end
+
+  def afterTextChanged(s)
+    @change_block.call(s) if @action == :after
+  end
+
+end

--- a/lib/project/ruby_motion_query/rmq/events.rb
+++ b/lib/project/ruby_motion_query/rmq/events.rb
@@ -3,9 +3,9 @@ class RMQ
     self.selected.each do |view|
       case event
       when :click, :tap, :touch
-        handle_click view
+        handle_click(view, &block)
       when :change
-        handle_change view
+        handle_change(view, &block)
       else
         raise "[RMQ ERROR] Unrecognized event: #{event}"
       end
@@ -15,7 +15,7 @@ class RMQ
 
   private
 
-  def handle_click view
+  def handle_click(view, &block)
     # Click event for ListItems
     if view.respond_to? :setOnItemClickListener
       view.onItemClickListener = RMQItemClick.new(&block)
@@ -25,8 +25,7 @@ class RMQ
     end
   end
 
-
-  def handle_change view
+  def handle_change(view, &block)
     # Seek bar change
     if view.respond_to? :setOnSeekBarChangeListener
       view.onSeekBarChangeListener = RMQSeekChange.new(args, &block)

--- a/lib/project/ruby_motion_query/rmq/events.rb
+++ b/lib/project/ruby_motion_query/rmq/events.rb
@@ -1,28 +1,42 @@
 class RMQ
   def on(event, args={}, &block)
     self.selected.each do |view|
-
       case event
       when :click, :tap, :touch
-        view.onClickListener = RMQClickHandler.new(&block)
+        handle_click view
+      when :change
+        handle_change view
       else
         raise "[RMQ ERROR] Unrecognized event: #{event}"
       end
-
     end
 
   end
-end
 
-class RMQClickHandler
-  attr_accessor :click_block
+  private
 
-  def initialize(&block)
-    @click_block = block
+  def handle_click view
+    # Click event for ListItems
+    if view.respond_to? :setOnItemClickListener
+      view.onItemClickListener = RMQItemClick.new(&block)
+    # Generic Click
+    else
+      view.onClickListener = RMQClick.new(&block)
+    end
   end
 
-  def onClick(view)
-    click_block.call(view)
+
+  def handle_change view
+    # Seek bar change
+    if view.respond_to? :setOnSeekBarChangeListener
+      view.onSeekBarChangeListener = RMQSeekChange.new(args, &block)
+    # Text change
+    elsif view.respond_to? :addTextChangeListener
+      view.addTextChangedListener(RMQTextChange.new(&block))
+    end
   end
 
 end
+
+
+


### PR DESCRIPTION
This commit adds the ability to click on listitems, as well as changing text and the seek bar.

I've restructured the way we build RMQ Events to be more scalable for all wrappers to come.