### PR TITLE
Added actions for action bar buttons

### DIFF
--- a/lib/project/pro_motion/pm_activity.rb
+++ b/lib/project/pro_motion/pm_activity.rb
@@ -38,6 +38,11 @@
     end
     def on_create_menu(_); end
 
+    def onOptionsItemSelected(item)
+      # Don't call super if method returns false
+      super unless on_options_item_selected(item) == false
+    end
+
   end
 
 #end

--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -185,9 +185,9 @@
       show_as_action = 4 if options[:show] == :with_text
       show_as_action = 8 if options[:show] == :collapse
 
-      btn = self.activity.menu.add(options.fetch(:group, 0), options.fetch(:item_id, @action_bar[:current_id] || 0), options.fetch(:order, 0), options.fetch(:title, "Untitled"))
+      btn = self.activity.menu.add(options.fetch(:group, 0), options.fetch(:item_id, @action_bar[:current_id] || 0), options.fetch(:order, 0), options.fetch(:title, ""))
       btn.setShowAsAction(show_as_action) if show_as_action
-      btn.setIcon(options[:icon]) if options[:icon]
+      btn.setIcon(image.resource(options[:icon].to_s)) if options[:icon]
       @action_bar[:button_actions][btn.getItemId] = options[:action] if options[:action]
       @action_bar[:current_id] = btn.getItemId + 1
       btn

--- a/lib/project/pro_motion/pm_single_fragment_activity.rb
+++ b/lib/project/pro_motion/pm_single_fragment_activity.rb
@@ -43,5 +43,9 @@
       self.fragment.on_create_menu(menu) if self.fragment
     end
 
+    def on_options_item_selected(item)
+      self.fragment.on_options_item_selected(item) if self.fragment
+    end
+
   end
 #end


### PR DESCRIPTION
You can now do:

```ruby
  def on_create_menu(menu)
    add_action_bar_button title: "Test 1", show: :if_room, action: :some_method
    add_action_bar_button title: "Test 2", show: :if_room, action: :some_other_method
  end
```

... and it'll work like ProMotion iOS.

Also added icon:

```ruby
  def on_create_menu(menu)
    add_action_bar_button icon: :my_icon, show: :if_room, action: :some_method
  end
```