### PR TITLE
Added ability to close to previous screen

### DIFF
--- a/lib/project/potion.rb
+++ b/lib/project/potion.rb
@@ -1,5 +1,6 @@
 module Potion
   Activity = Android::App::Activity
+  Intent = Android::Content::Intent
   View = Android::View::View
   ViewGroup = Android::View::ViewGroup
   Integer = Java::Lang::Integer

--- a/lib/project/pro_motion/pm_activity.rb
+++ b/lib/project/pro_motion/pm_activity.rb
@@ -17,6 +17,7 @@
 
     def onResume
       super
+      on_resume
       PMApplication.current_application.current_activity = self
     end
 

--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -115,8 +115,9 @@
       # we're taking a conservative approach for now - eventually we'll want to allow
       # replacing fragments for any kind of activity, but I'm not sure of the best way
       # to implement that yet
-      intent = Android::Content::Intent.new(self.activity, activity_class)
+      intent = Potion::Intent.new(self.activity, activity_class)
       intent.putExtra PMSingleFragmentActivity::EXTRA_FRAGMENT_CLASS, screen_class.to_s
+      intent.setFlags(Potion::Intent::FLAG_ACTIVITY_CLEAR_TOP) if options.delete(:close)
 
       if extras = options.delete(:extras)
         extras.keys.each do |key, value|
@@ -135,11 +136,16 @@
     end
 
     def close(options={})
-      self.activity.finish
+      if options[:to_screen]
+        mp "You must provide a custom activity if you want to use `close to_screen:`. Open your screen with a custom activity and then `close to_screen: <screen>, activity: <activity>`." unless options[:to_activity]
+        open options[:to_screen], activity: options[:activity], close: true
+      else
+        self.activity.finish
+      end
     end
 
     def start_activity(activity_class)
-      intent = Android::Content::Intent.new(self.activity, activity_class)
+      intent = Potion::Intent.new(self.activity, activity_class)
       #intent.putExtra("key", value); # Optional parameters
       self.activity.startActivity(intent)
     end

--- a/lib/project/pro_motion/pm_screen_module.rb
+++ b/lib/project/pro_motion/pm_screen_module.rb
@@ -137,7 +137,7 @@
 
     def close(options={})
       if options[:to_screen]
-        mp "You must provide a custom activity if you want to use `close to_screen:`. Open your screen with a custom activity and then `close to_screen: <screen>, activity: <activity>`." unless options[:to_activity]
+        mp "You must provide a custom activity if you want to use `close to_screen:`. Open your screen with a custom activity and then `close to_screen: <screen>, activity: <activity>`." unless options[:activity]
         open options[:to_screen], activity: options[:activity], close: true
       else
         self.activity.finish

--- a/lib/project/pro_motion/pm_single_fragment_activity.rb
+++ b/lib/project/pro_motion/pm_single_fragment_activity.rb
@@ -12,6 +12,16 @@
 
       mp "PMSingleFragmentActivity on_create", debugging_only: true
 
+      setup_fragment
+    end
+
+    def on_resume
+      mp "PMSingleFragmentActivity on_resume", debugging_only: true
+
+      setup_fragment unless @fragment_container
+    end
+
+    def setup_fragment
       @fragment_container = Potion::FrameLayout.new(self)
       @fragment_container.setId Potion::ViewIdGenerator.generate
       self.contentView = @fragment_container


### PR DESCRIPTION
So, @GantMan and @darinwilson and @leonskim and I worked on this one for quite a while. The upshot is that you need to provide a custom activity if you want to use `close to_screen`.

```ruby
class MyActivity < PMSingleFragmentActivity
end

# ...
open MyScreen, activity: MyActivity

# ...
close to_screen: MyScreen, activity: MyActivity
```

If you don't provide an activity both when you open the screen and when you close to it, it won't work.