### PR TITLE
Change load_view semantics to match ProMotion-ios

### DIFF
--- a/lib/project/pro_motion/fragments/pm_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_screen.rb
@@ -22,7 +22,8 @@
       if @xml_resource = self.class.xml_resource
         @view = inflater.inflate(r(:layout, @xml_resource), parent, false)
       else
-        @view = load_view
+        v = load_view
+        @view ||= v
         @view.setId Potion::ViewIdGenerator.generate
       end
 


### PR DESCRIPTION
In ProMotion-iOS, `load_view` expects you to assign the view:

```ruby
def load_view
  self.view = UIView.new
end
```

This brings ProMotion-Android in line with that.

```ruby
def load_view
  self.view = Potion::FrameLayout.new(self.activity)
end
```

It's backwards-compatible, in that if you do *not* assign the view but rather return it, PM-android will do the right thing and assign it for you.

```ruby
def load_view
  Potion::FrameLayout.new(self.activity) # assigned to self.view anyway
end
```

