### PR TITLE
Integrate motion-async for asychronous tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gemspec
 gem 'newclear'
 gem "motion-gradle", github: 'HipByte/motion-gradle' # Dynamically Load JARs
 gem "moran"         # Fast JSON Parser
+gem "motion-async"  # AsyncTask wrapper
 
 # Add your dependencies here:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
   specs:
     moran (0.0.2)
       motion-gradle
+    motion-async (0.5)
     newclear (1.1)
       reset-sim
     rake (10.4.2)
@@ -25,6 +26,7 @@ PLATFORMS
 DEPENDENCIES
   bluepotion!
   moran
+  motion-async
   motion-gradle!
   newclear
   rake

--- a/app/screens/home_screen.rb
+++ b/app/screens/home_screen.rb
@@ -31,6 +31,22 @@ class HomeScreen < PMScreen
       open ExampleTableScreen, people: ["Todd", "Darin", "Gant", "Jamon"], test_int: 123, test_symbol: :my_symbol
     end
 
+    append(Potion::Button, :countdown_button).on(:tap) do |sender|
+      original_text = sender.text
+      sender.enabled = false
+      app.async do |task|
+        5.times do |i|
+          task.progress(5 - i)
+          sleep 1
+        end
+      end.on(:progress) do |count|
+        sender.text = "     #{count}      "
+      end.on(:completion) do
+        sender.text = original_text
+        sender.enabled = true
+      end
+    end
+
     append(Potion::CalendarView, :calendar)
 
     debug

--- a/app/stylesheets/application_stylesheet.rb
+++ b/app/stylesheets/application_stylesheet.rb
@@ -12,6 +12,7 @@ class ApplicationStylesheet < RMQStylesheet
     color.add_named :potion_blue,   "#3759FE"
     color.add_named :mustard,       "#FFFF00"
     color.add_named :nice_blue,     "#87C9FF"
+    color.add_named :light_blue,    '#69C3EE'
   end
 
   def standard_text_view(st)

--- a/app/stylesheets/home_screen_stylesheet.rb
+++ b/app/stylesheets/home_screen_stylesheet.rb
@@ -42,6 +42,13 @@ class HomeScreenStylesheet < ApplicationStylesheet
     st.text = "Open table screen"
   end
 
+  def countdown_button(st)
+    standard_button(st)
+    st.background_color = color.light_blue
+    st.color = color.black
+    st.text = "Run Countdown"
+  end
+
   def calendar(st)
     st.layout = {w: :full, h: 400}
     st.background_color = color.black

--- a/lib/project/pro_motion/pm_application.rb
+++ b/lib/project/pro_motion/pm_application.rb
@@ -85,6 +85,10 @@
       BluePotionNet
     end
 
+    def async(options={}, &block)
+      MotionAsync.async(options, &block)
+    end
+
     class << self
       attr_accessor :current_application, :home_screen_class
 


### PR DESCRIPTION
This adds `app.async` as a wrapper for the [motion-async](https://github.com/darinwilson/motion-async) gem, and adds some sample usage to the BluePotion app home screen.

Resolves #17 