### PR TITLE
Add an example XML screen, and modify fragment loading behavior

### DIFF
--- a/app/screens/example_table_screen.rb
+++ b/app/screens/example_table_screen.rb
@@ -1,5 +1,5 @@
 class ExampleTableScreen < PMScreen
-  uses_action_bar true
+  action_bar true
   stylesheet ExampleTableScreenStylesheet
   title "Example Table Screen"
 

--- a/app/screens/example_xml_screen.rb
+++ b/app/screens/example_xml_screen.rb
@@ -1,20 +1,14 @@
 class ExampleXmlScreen < PMScreen
-
-  # If you are using XML for this screen:
-  #uses_xml :example_xml
-
-  uses_action_bar true
-  stylesheet ExampleXmlScreenStylesheet
-
-  # Title is unnecesary if you're using an XML file
-  title "Your title here"
-
-  # This is optional, it will default to a RelativeView or use your XML file
-  #def load_view
-    #Potion::LinearLayout.new(self.activity)
-  #end
+  xml_layout :example_xml_screen
+  title "Example XML Screen"
+  action_bar true, back: true
 
   def on_load
-    append(Potion::TextView, :hello_label)
+    find(:left_button).on(:tap) do
+      app.toast("Left button clicked")
+    end
+    find(:right_button).on(:tap) do
+      open ExampleTableScreen, people: ["Todd", "Darin", "Gant", "Jamon"], test_int: 123, test_symbol: :my_symbol
+    end
   end
 end

--- a/app/screens/home_screen.rb
+++ b/app/screens/home_screen.rb
@@ -1,7 +1,7 @@
 class HomeScreen < PMScreen
   title "BluePotion Home"
   stylesheet HomeScreenStylesheet
-  action_bar true
+  action_bar true, icon: true, back: false
 
   # This will automatically set to a RelativeLayout if you don't override this method
   def load_view
@@ -25,6 +25,10 @@ class HomeScreen < PMScreen
 
     append(Potion::Button, :dialog_button).on(:tap) do |sender|
       PotionDialog.new(xml_layout: app.resource.layout(:blue_potion_dialog), w: 500, h: 500)
+    end
+
+    append(Potion::Button, :xml_button).on(:tap) do |sender|
+      open ExampleXmlScreen
     end
 
     append(Potion::Button, :open_example_table_button).on(:tap) do |sender|

--- a/app/stylesheets/home_screen_stylesheet.rb
+++ b/app/stylesheets/home_screen_stylesheet.rb
@@ -35,6 +35,13 @@ class HomeScreenStylesheet < ApplicationStylesheet
     st.text = "Open Dialog"
   end
 
+  def xml_button(st)
+    standard_button(st)
+    st.background_color = color.nice_blue
+    st.color = color.black
+    st.text = "Open XML Screen"
+  end
+
   def open_example_table_button(st)
     standard_button(st)
     st.background_color = color.potion_blue

--- a/lib/project/pro_motion/activities/pm_activity.rb
+++ b/lib/project/pro_motion/activities/pm_activity.rb
@@ -51,17 +51,6 @@
       super
     end
 
-    def onBackPressed
-      # return if self.fragment && self.fragment.on_back_pressed == false
-      super
-      if self.fragment
-        self.fragment.set_up_action_bar
-        self.fragment.on_return
-      else
-        self.finish
-      end
-    end
-
     def open(screen, options={})
       find.screen.open screen, options
     end

--- a/lib/project/pro_motion/activities/pm_navigation_activity.rb
+++ b/lib/project/pro_motion/activities/pm_navigation_activity.rb
@@ -22,7 +22,7 @@
     def open_fragment(frag, options={})
       mp frag
       mgr = fragmentManager.beginTransaction
-      mgr.add(@fragment_container.getId, frag, "screen-#{fragmentManager.getBackStackEntryCount + 1}")
+      mgr.replace(@fragment_container.getId, frag, "screen-#{fragmentManager.getBackStackEntryCount + 1}")
       mgr.addToBackStack(nil)
       mgr.commit
       frag

--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -90,7 +90,7 @@
         @view.setId Potion::ViewIdGenerator.generate
       end
 
-      set_up_action_bar(self.class.get_action_bar)
+      set_up_action_bar(self.class.action_bar_options)
 
       on_create_view(inflater, parent, saved_instance_state)
 

--- a/lib/project/pro_motion/fragments/pm_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_screen.rb
@@ -27,7 +27,7 @@
         @view.setId Potion::ViewIdGenerator.generate
       end
 
-      set_up_action_bar(self.class.get_action_bar)
+      set_up_action_bar(self.class.action_bar_options)
 
       on_create_view(inflater, parent, saved_instance_state)
 

--- a/lib/project/pro_motion/fragments/pm_screen_module.rb
+++ b/lib/project/pro_motion/fragments/pm_screen_module.rb
@@ -28,13 +28,13 @@
       #     custom_icon: "resourcename", custom_back: "custombackicon"
       #
       def action_bar(show_action_bar, opts={})
-        @show_action_bar = ({show:true, back: true, icon: false}).merge(opts).merge({show: show_action_bar})
+        @action_bar_options = ({show:true, back: true, icon: false}).merge(opts).merge({show: show_action_bar})
       end
       alias_method :nav_bar, :action_bar
       alias_method :uses_action_bar, :action_bar
 
-      def get_action_bar
-        @show_action_bar ||= action_bar(true, {})
+      def action_bar_options
+        @action_bar_options ||= action_bar(true, {})
       end
 
       def title(new_title)
@@ -221,7 +221,7 @@
       activity.menu
     end
 
-    def set_up_action_bar(options)
+    def set_up_action_bar(options={})
       if options[:show]
         action_bar.show
         action_bar.setDisplayHomeAsUpEnabled(!!options[:back])

--- a/resources/layout/example_xml_screen.xml
+++ b/resources/layout/example_xml_screen.xml
@@ -1,7 +1,33 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="fill_parent"
-    android:layout_height="match_parent"
-    android:background="#00000000"
-    android:orientation="vertical">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:gravity="center"
+  android:orientation="vertical" >
 
-</RelativeLayout>
+   <TextView
+     android:layout_width="wrap_content"
+     android:layout_height="wrap_content"
+     android:padding="24dp"
+     android:text="Hello, BluePotion" />
+
+   <LinearLayout
+     android:layout_width="wrap_content"
+     android:layout_height="wrap_content"
+     android:gravity="center"
+     android:orientation="horizontal" >
+
+     <Button
+       android:id="@+id/left_button"
+       android:layout_width="wrap_content"
+       android:layout_height="wrap_content"
+       android:text="Click me" />
+
+     <Button
+       android:id="@+id/right_button"
+       android:layout_width="wrap_content"
+       android:layout_height="wrap_content"
+       android:text="Or Click Me" />
+
+   </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
This gets the example XML layout screen working, which required a change to the way fragments are pulled on screen. We're now using `replace` rather than `add`, which fixes the problem of old fragments appearing underneath the current fragment. 

This change also works better with the hardware back button, so we could get rid of our hand-rolled implementation of `onBackPressed`