### PR TITLE
Fix another conflict with a simiarly-named Java method

### DIFF
--- a/lib/project/ruby_motion_query/rmq/selectors.rb
+++ b/lib/project/ruby_motion_query/rmq/selectors.rb
@@ -10,7 +10,7 @@ class RMQ
     @_selectors
   end
 
-  def match(view, new_selectors)
+  def match(view, new_selectors, dummy=nil)
     out = false
 
     # This method is written strange because the return in this example doesn't actually return (RM bug)


### PR DESCRIPTION
In this case, the culprit was `match` and it didn't happen on all API versions.