### PR TITLE
Fix for stale adapter data during update_table_data

### DIFF
--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -65,6 +65,11 @@
     end
 
     def update_table_data
+      # base adapters must reacquire their data from the PMListScreen "delegate"
+      if adapter.is_a?(PMBaseAdapter)
+        td = table_data
+        adapter.data = td && td.first && td.first[:cells]
+      end
       adapter.notifyDataSetChanged
     end
 


### PR DESCRIPTION
Before triggering `adapter.notifyDataSetChanged`, we need to feed it the changed data from our `PMListScreen`.