### PR TITLE
Remove warning when cells aren't :update powered.

### DIFF
--- a/lib/project/pro_motion/adapters/pm_base_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_base_adapter.rb
@@ -86,8 +86,6 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
     elsif view.is_a?(Potion::TextView)
       # Specific to use of Simple list item 1
       view.text = data[:title]
-    else
-      mp "We don't know how to update your cell"
     end
   end
 

--- a/lib/project/pro_motion/adapters/pm_base_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_base_adapter.rb
@@ -74,7 +74,11 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
     if update.is_a?(Proc)
       update.call(out, data)
     elsif update.is_a?(Symbol) || update.is_a?(String)
-      find.screen.send(update, view, data)
+      if find.screen.respond_to?(update)
+        find.screen.send(update, view, data)
+      else
+        mp "Warning: #{find.screen.class} does not respond to #{update}"
+      end
     elsif data[:properties]
       data[:properties].each do |k, v|
         if view.respond_to?("#{k}=")
@@ -86,6 +90,8 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
     elsif view.is_a?(Potion::TextView)
       # Specific to use of Simple list item 1
       view.text = data[:title]
+    elsif update
+      mp "We don't know how to update your cell"
     end
   end
 


### PR DESCRIPTION
Cells that are powered by just a layout file don't need to handle `#update`.  Just removing the warning cry from bp.