### PR TITLE
Cell reuse

### DIFF
--- a/lib/project/pro_motion/adapters/pm_base_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_base_adapter.rb
@@ -47,7 +47,7 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
     if data_item[:prevent_reuse]
       Android::Widget::Adapter::IGNORE_ITEM_VIEW_TYPE
     else
-      idx = @view_types.index(data_item[:view_type])
+      idx = @view_types.index(data_item[:cell_type] || data_item[:view_type])
       idx = 0 if idx < 0
       idx
     end

--- a/lib/project/pro_motion/adapters/pm_base_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_base_adapter.rb
@@ -1,9 +1,11 @@
 class PMBaseAdapter < Android::Widget::BaseAdapter
   attr_accessor :data
+  attr_accessor :view_types
 
   def initialize(opts={})
     super()
-    @data = opts.fetch(:data, [])
+    self.data = opts.fetch(:data, [])
+    self.view_types = opts.fetch(:view_types, []) || []
   end
 
   def screen
@@ -35,12 +37,20 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
 
   def getViewTypeCount(); view_type_count; end
   def view_type_count()
-    1
+    # named or not, we need at least one
+    @view_types.count > 0 ? @view_types.count : 1
   end
 
   def getItemViewType(position); item_view_type_id(position); end
   def item_view_type_id(position)
-    0
+    data_item = @data[position]
+    if data_item[:prevent_reuse]
+      Android::Widget::Adapter::IGNORE_ITEM_VIEW_TYPE
+    else
+      idx = @view_types.index(data_item[:view_type])
+      idx = 0 if idx < 0
+      idx
+    end
   end
 
   def getCount(); count(); end

--- a/lib/project/pro_motion/adapters/pm_cursor_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_cursor_adapter.rb
@@ -17,6 +17,10 @@ class PMCursorAdapter < PMBaseAdapter
     cursor
   end
 
+  def item_view_type_id(position)
+    0
+  end
+
   def view(position, convert_view, parent)
     data = item(position)
     out = convert_view || rmq.create!(cell_options[:cell_class] || Potion::TextView)

--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -1,8 +1,27 @@
 # http://hipbyte.myjetbrains.com/youtrack/issue/RM-773 - can't put this in a module yet :(
 #module ProMotion
 
+  module PMListReusability
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+
+      attr_reader :pm_cell_types
+
+      def cell_types(new_cell_types=[])
+        @pm_cell_types ||= new_cell_types
+      end
+
+    end
+  end
+
+
   class PMListScreen < Android::App::ListFragment
     include PMScreenModule
+    include PMListReusability
 
     attr_accessor :view
 
@@ -57,7 +76,7 @@
         td = table_data
         if td.is_a?(Array)
           cells = td.first[:cells]
-          PMBaseAdapter.new(data: cells)
+          PMBaseAdapter.new(data: cells, view_types: self.class.pm_cell_types)
         elsif td.is_a?(Hash)
           mp "Please supply a cursor in #{self.inspect}#table_data." unless td[:cursor]
           PMCursorAdapter.new(td)


### PR DESCRIPTION
You can now opt-in to cell reuse with multiple types.  Android calls these "view types" in the adapter.

iOS uses `reuseIdentifier` and manages that list automatically.  Android makes you define them all up front, even when your currently doesn't show them.  You seem to not be able to add them later.  :/

In your screen:
```ruby
class Listicle < PMListScreen

  # tell the list screen about all the types
  cell_types [:normal, :sleek, :fabulous]

  # then pick one of these cell types as you define your table data
  def table_data
    [{cells: [
        {cell_type: :normal ... },
        {cell_type: :normal ... },
        {cell_type: :fabulous ... },
    ]}]
  end

end
```

Support also for a single-cell to opt-out of reuse.

```ruby
{cell_type: :sleek, prevent_reuse: true}
```

