### PR TITLE
Only set the font when it actually changes.

### DIFF
--- a/lib/project/ruby_motion_query/stylers/rmq_text_view_styler.rb
+++ b/lib/project/ruby_motion_query/stylers/rmq_text_view_styler.rb
@@ -5,6 +5,7 @@ class RMQTextViewStyler < RMQViewStyler
 
   def font_family=(font_family)
     @font_family = font_family
+    @lazy_typeface = true
   end
 
   def text_style=(text_style)
@@ -19,6 +20,7 @@ class RMQTextViewStyler < RMQViewStyler
       when "normal"
         Android::Graphics::Typeface::NORMAL
       end
+    @lazy_typeface = true
   end
 
   def text_color=(text_color)
@@ -47,8 +49,10 @@ class RMQTextViewStyler < RMQViewStyler
 
   def finalize
     super
-    @text_style ||= Android::Graphics::Typeface::NORMAL
-    typeface = Android::Graphics::Typeface.create(@font_family, @text_style) if @font_family
-    @view.setTypeface(typeface, @text_style) # ok for typeface to be nil
+    if @lazy_typeface
+      @text_style ||= Android::Graphics::Typeface::NORMAL
+      typeface = Android::Graphics::Typeface.create(@font_family, @text_style) if @font_family
+      @view.setTypeface(typeface, @text_style) # ok for typeface to be nil
+    end
   end
 end


### PR DESCRIPTION
The `finalize` of the text styler was overriding the styling applied in our layout xml file.

I'll follow up with @darinwilson to see if we can eliminate dodging lazy style applying as a best practice.  It may not be easy as some Android need to be set in pairs (layout params) or sub objects (typeface).

Perhaps we could start introducing hash-based property if we're required.  Like good ol'  `:frame`.

I encountered some of these things in `motion-mastr` as the NSAttributedString customization involved sub-objects (NSParagraphStyle).   But then again, `motion-mastr`'s interface is entirely hash-based.

Now I'm rambling.  Now's the time! The time is now!