### PR TITLE
Tag all inflated rows spawned by the base adapter.

### DIFF
--- a/lib/project/pro_motion/adapters/pm_base_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_base_adapter.rb
@@ -119,6 +119,7 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
         row_view = rmq.create!(data[:cell_class])
       elsif data[:cell_xml]
         row_view = inflate_row(data[:cell_xml])
+        rmq.tag_all_from_resource_entry_name(row_view)
       else
         # Default is Sipmle List Item 1
         # TODO:  Possibly use Android::R::Layout::Simple_list_item_2 which has subtitle


### PR DESCRIPTION
Wasn't able to `find(:cell_label)` after cells were created.  Just needed to tag 'em up.