### PR TITLE
Guard against a crash when app.dialog isn't given style: :input.

### DIFF
--- a/lib/project/alert_dialog/alert_dialog.rb
+++ b/lib/project/alert_dialog/alert_dialog.rb
@@ -75,7 +75,7 @@ class AlertDialog < Android::App::DialogFragment
     button_text = (id == Android::App::AlertDialog::BUTTON_POSITIVE) ? @options[:positive_button] : @options[:negative_button]
 
     # if a text_view is present, grab what the user gave us
-    text_view = dialog.findViewById(@text_view_id)
+    text_view = @text_view_id && dialog.findViewById(@text_view_id)
     input_text = text_view ? text_view.text.toString : nil
 
     @callback.call(button_text, input_text) if @callback


### PR DESCRIPTION
The kind of crash that gives you no info.    

On Android 4 it dumps the activity.  You get Dalvik'd.

On Android 5 it spews misinformation at you.

I actually ended up running it on the device to figure out the real problem.  

So strange.

