### PR TITLE
Fix Cursor Adapter Issues

### DIFF
--- a/lib/project/pro_motion/adapters/pm_base_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_base_adapter.rb
@@ -76,9 +76,17 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
     out = selected_view(convert_view, data)
     update_view(out, data)
     if data[:action]
-      find(out).on(:tap) { find.screen.send(data[:action], data[:arguments], position) }
+      find(out).on(:tap) do
+        arguments = action_arguments data, position
+        find.screen.send(data[:action], arguments, position) 
+      end
     end
     out
+  end
+
+  # configure what to pass back when we tap that action
+  def action_arguments(data, position)
+    data[:arguments]
   end
 
   def update_view(view, data)

--- a/lib/project/pro_motion/adapters/pm_base_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_base_adapter.rb
@@ -41,7 +41,7 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
 
   def getItemViewType(position); item_view_type_id(position); end
   def item_view_type_id(position)
-    data_item = @data[position]
+    data_item = self.item_data(position)
     idx = nil
     if data_item[:prevent_reuse]
       idx = Android::Widget::Adapter::IGNORE_ITEM_VIEW_TYPE

--- a/lib/project/pro_motion/adapters/pm_cursor_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_cursor_adapter.rb
@@ -6,51 +6,16 @@ class PMCursorAdapter < PMBaseAdapter
     super()
     @cursor = opts.fetch(:cursor)
     @cell_options = opts.fetch(:cell, 1)
+    @cell_options[:cursor] = @cursor # slip the cursor inside so callbacks have it
   end
 
   def count
     cursor.count
   end
 
-  def item(position)
+  def item_data(position)
     cursor.moveToPosition(position)
-    cursor
+    cell_options # return the one & only one cell_options
   end
-
-  def item_view_type_id(position)
-    0
-  end
-
-  def view(position, convert_view, parent)
-    data = item(position)
-    out = convert_view || rmq.create!(cell_options[:cell_class] || Potion::TextView)
-    update_view(out, data)
-    if cell_options[:action]
-      find(out).on(:tap) do
-        find.screen.send(cell_options[:action], item(position), position)
-      end
-    end
-    out
-  end
-
-  def update_view(out, data)
-    if cell_options[:update].is_a?(Proc)
-      cell_options[:update].call(out, data)
-    elsif cell_options[:update].is_a?(Symbol) || cell_options[:update].is_a?(String)
-      find.screen.send(cell_options[:update], out, data)
-    else
-      out.text = data.getString(cell_options[:title_column].to_i)
-    end
-  end
-
-end
-
-__END__
-
-def table_data
-  {
-    cursor: my_cursor,
-    title_column: 0,
-  }
 end
 

--- a/lib/project/pro_motion/adapters/pm_cursor_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_cursor_adapter.rb
@@ -17,5 +17,12 @@ class PMCursorAdapter < PMBaseAdapter
     cursor.moveToPosition(position)
     cell_options # return the one & only one cell_options
   end
+
+  # slighty different arguments to send when tapping
+  def action_arguments(data, position)
+    item_data(position) # move the cursor into position
+    @cursor
+  end
+
 end
 


### PR DESCRIPTION
Two things.

1. Recently the interface for `item` changed to `item_data` in base adapter.  This commit brings that up to par.

2.  Also, turns out, base adapter already has the implementation of creating/reusing/prepping views, so I nuked all that inside here as it was slightly out of date anyway.

For science!

