### PR TITLE
Keyboard pan mode to prevent ui control squishing.

### DIFF
--- a/lib/project/pro_motion/fragments/pm_screen_module.rb
+++ b/lib/project/pro_motion/fragments/pm_screen_module.rb
@@ -237,6 +237,8 @@
         case mode
         when :adjust_resize
           Android::View::WindowManager::LayoutParams::SOFT_INPUT_ADJUST_RESIZE
+        when :adjust_pan
+          Android::View::WindowManager::LayoutParams::SOFT_INPUT_ADJUST_PAN
         end
       activity.getWindow().setSoftInputMode(mode_const)
     end


### PR DESCRIPTION
This mode allows the keyboard to sit ontop of the controls.  UI Controls won't reflow.