### PR TITLE
Expose the Potion::Dialog from the PotionDialog.

### DIFF
--- a/lib/project/potion_dialog/potion_dialog.rb
+++ b/lib/project/potion_dialog/potion_dialog.rb
@@ -1,18 +1,23 @@
 class PotionDialog
 
-  def initialize(options)
+  attr_reader :dialog
 
+  def initialize(options)
+    @dialog = setup(options)
+  end
+
+  def setup(options)
     @width = options[:width] || options[:w]
     @height = options[:height] || options[:h]
 
     # err if missing required options
     raise "[BluePotion ERROR] PotionDialog#initialize Requires an xml_layout" unless options[:xml_layout]
     raise "[BluePotion ERROR] PotionDialog#initialize Cannot have width without height" if @width && !@height
-    raise "[BluePotion ERROR] PotionDialog#initialize Cannot have height without width" if @height && !@width    
-    
-    # Merging defaults    
-    opts = { 
-      title: false, 
+    raise "[BluePotion ERROR] PotionDialog#initialize Cannot have height without width" if @height && !@width
+
+    # Merging defaults
+    opts = {
+      title: false,
       show: true
     }.merge(options)
 
@@ -28,7 +33,7 @@ class PotionDialog
     dialog = Potion::Dialog.new(find.activity)
 
     # manage title
-    if options[:title] 
+    if options[:title]
       dialog.title = options[:title]
     else
       dialog.requestWindowFeature(Potion::Window::FEATURE_NO_TITLE)
@@ -40,7 +45,7 @@ class PotionDialog
     # set width and height of Dialog Window
     if @width && @height
       dialog.window.setLayout(@width, @height)
-    end 
+    end
     dialog
   end
 end


### PR DESCRIPTION
I needed to get the `Android::App::Dialog`, but it was trapped inside the `PotionDialog`.

I'm finding this interface a bit confusing to be honest.  Maybe it's the name?  Maybe I expected `PotionDialog` to be an `Android::App::Dialog`.

I think end game would be have this dialog be an `PMScreen`, but I'm having a hard time wrapping my head around how to make that happen as `PMScreen`s are `Fragment`s.

This commit unblocks me though!  I can `findViewById` and `rmq.wrap` to accomplish what i need short-term.