### PR TITLE
Basic Refreshable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,10 +17,10 @@ Motion::Project::App.setup do |app|
   app.theme = "@android:style/Theme.Holo.Light"
   app.permissions = [:internet, :access_network_state] # :access_coarse_location, :access_fine_location, :write_external_storage
   app.icon = 'ic_launcher'
-  
+
   # Version name is for you - version code must always be higher in Google Play (tied to git builds)
   # app.version_name = "1.0.0"
-  # app.version_code = (`git rev-list HEAD --count`.strip.to_i).to_s  
+  # app.version_code = (`git rev-list HEAD --count`.strip.to_i).to_s
 
   app.application_class = "BluePotionApplication"
   app.main_activity = "PMHomeActivity"
@@ -32,6 +32,9 @@ Motion::Project::App.setup do |app|
 
     # support lib
     dependency "com.android.support", artifact: "support-v4", version: "18.0.+"
+
+    # pull to refresh
+    dependency 'in.srain.cube:ultra-ptr:1.0.10'
 
     # Google's Android Play Services
     #dependency 'com.android.support', :artifact => 'appcompat-v7', :version => '21.0.3'

--- a/app/screens/example_partial_list_xml_screen.rb
+++ b/app/screens/example_partial_list_xml_screen.rb
@@ -9,6 +9,11 @@ class ExamplePartialListXML < PMListScreen
     }]
   end
 
+  def on_refresh
+    mp "I was refreshed!"
+    update_table_data
+    stop_refreshing
+  end
 
   private
 

--- a/app/screens/example_partial_list_xml_screen.rb
+++ b/app/screens/example_partial_list_xml_screen.rb
@@ -1,4 +1,5 @@
 class ExamplePartialListXML < PMListScreen
+  refreshable
   xml_layout :embedded_listview
   title "View with a ListView Inside"
 

--- a/app/screens/example_table_screen.rb
+++ b/app/screens/example_table_screen.rb
@@ -3,10 +3,10 @@ class ExampleTableScreen < PMListScreen
   stylesheet ExampleTableScreenStylesheet
   title "Example Table Screen"
 
-  def load_view
-    mp "ExampleTableScreen load_view"
-    Potion::ListView.new(self.activity)
-  end
+  # def load_view
+  #   mp "ExampleTableScreen load_view"
+  #   Potion::ListView.new(self.activity)
+  # end
 
   def table_data
     states = [

--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -85,42 +85,6 @@
       @_extra_view_types ||= extra_types
     end
 
-
-
-
-    ############## THIS SHOULD BE IN A SEPARATE FILE ##############
-    ###############  RMA WOULDN"T LET ME USE A MODULE #############
-
-    def make_refreshable(params={})
-      @ptr = find!(In::Srain::Cube::Views::Ptr::PtrFrameLayout)
-      header = In::Srain::Cube::Views::Ptr::Header::MaterialHeader.new(app.context)
-      ptr_colors = params[:color_array] || [color.dark_gray]
-      header.setColorSchemeColors(ptr_colors)
-      header.setPtrFrameLayout(@ptr)
-      @ptr.setHeaderView(header)
-      @ptr.addPtrUIHandler(header)
-      @ptr.ptrHandler = PTRHandler.new do |frame|
-        on_refresh if respond_to?(:on_refresh)
-      end
-    end
-
-    def self.refreshable(params = {})
-      @refreshable_params = params
-      @refreshable = true
-    end
-
-    def self.get_refreshable
-      @refreshable ||= false
-    end
-
-    def self.get_refreshable_params
-      @refreshable_params ||= nil
-    end
-
-    def stop_refreshing
-      @ptr.refreshComplete
-    end
-
   end
 
 #end

--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -2,10 +2,23 @@
 #module ProMotion
 
   class PMListScreen < PMScreen
+    include RefreshableList
 
     def table_data
       mp "Implement a table_data method in #{self.inspect}."
       []
+    end
+
+    def screen_setup
+      # This method will grow as BP grows towards RP
+      set_up_refreshable
+    end
+
+    def set_up_refreshable
+      # named get_refreshable bc of Promotion # Possible PR to is_refreshable?
+      if self.class.respond_to?(:get_refreshable) && self.class.get_refreshable
+        make_refreshable(self.class.get_refreshable_params)
+      end
     end
 
     def load_view
@@ -60,6 +73,45 @@
       @_extra_view_types ||= extra_types
     end
 
-  end
+
+
+
+    ############## THIS SHOULD BE IN A SEPARATE FILE ##############
+    ###############  RMA WOULDN"T LET ME USE A MODULE #############
+
+
+
+    def make_refreshable(params={})
+      @ptr = find!(In::Srain::Cube::Views::Ptr::PtrFrameLayout)
+      header = In::Srain::Cube::Views::Ptr::Header::MaterialHeader.new(app.context)
+      ptr_colors = params[:color_array] || [color.dark_gray]
+      header.setColorSchemeColors(ptr_colors)
+      header.setPtrFrameLayout(@ptr)
+      @ptr.setHeaderView(header)
+      @ptr.addPtrUIHandler(header)
+      @ptr.ptrHandler = PtrHandler.new do |frame|
+        # should call on_refresh if respond_to?(:on_refresh)
+        frame.refreshComplete
+      end
+    end
+
+    def self.refreshable(params = {})
+      @refreshable_params = params
+      @refreshable = true
+    end
+
+    def self.get_refreshable
+      @refreshable ||= false
+    end
+
+    def self.get_refreshable_params
+      @refreshable_params ||= nil
+    end
+
+    def stop_refreshing
+      @ptr.refreshComplete
+    end
+
+    end
 
 #end

--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -22,9 +22,21 @@
     end
 
     def load_view
-      v = Potion::View.new(app.context) # TODO, fix this horrible hack
-      lv = rmq(v).create(Potion::ListView).tag(:list)
-      self.view = lv.get
+      # Dynamic Pull to Refresh?
+      # v = Potion::View.new(app.context) # TODO, fix this horrible hack
+      # ptr_v = rmq(v).create(In::Srain::Cube::Views::Ptr::PtrClassicFrameLayout).tag(:ptr_parent).style do |st|
+      #   st.layout_width = :wrap_content
+      #   st.layout_height = :wrap_content
+      #   st.background_color = rmq.color.black
+      # end
+      # lv = ptr_v.append(Potion::ListView).tag(:list)
+      # self.view = ptr_v.get
+
+
+      # FOR NOW
+
+      # We need a simple listview - that's all
+      Potion::ListView.new(app.context)
     end
 
     def extended_screen_setup

--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -79,8 +79,6 @@
     ############## THIS SHOULD BE IN A SEPARATE FILE ##############
     ###############  RMA WOULDN"T LET ME USE A MODULE #############
 
-
-
     def make_refreshable(params={})
       @ptr = find!(In::Srain::Cube::Views::Ptr::PtrFrameLayout)
       header = In::Srain::Cube::Views::Ptr::Header::MaterialHeader.new(app.context)
@@ -89,9 +87,8 @@
       header.setPtrFrameLayout(@ptr)
       @ptr.setHeaderView(header)
       @ptr.addPtrUIHandler(header)
-      @ptr.ptrHandler = PtrHandler.new do |frame|
-        # should call on_refresh if respond_to?(:on_refresh)
-        frame.refreshComplete
+      @ptr.ptrHandler = PTRHandler.new do |frame|
+        on_refresh if respond_to?(:on_refresh)
       end
     end
 
@@ -112,6 +109,6 @@
       @ptr.refreshComplete
     end
 
-    end
+  end
 
 #end

--- a/lib/project/pro_motion/fragments/pm_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_screen.rb
@@ -67,7 +67,11 @@
     def on_load; end
     def on_activity_created; end
 
-    def onStart; super; on_start; end
+    def onStart
+      super
+      screen_setup if self.respond_to?(:screen_setup)
+      on_start
+    end
     def on_start; end
     alias :on_appear :on_start
 

--- a/lib/project/pro_motion/fragments/refreshable_list.rb
+++ b/lib/project/pro_motion/fragments/refreshable_list.rb
@@ -1,34 +1,39 @@
-# # Should be included in PMListScreen but RMA is acting up
 module RefreshableList
 
-#   def make_refreshable(params={})
-#     @ptr = find!(In::Srain::Cube::Views::Ptr::PtrFrameLayout)
-#     header = In::Srain::Cube::Views::Ptr::Header::MaterialHeader.new(app.context)
-#     ptr_colors = params[:color_array] || [color.dark_gray]
-#     header.setColorSchemeColors(ptr_colors)
-#     header.setPtrFrameLayout(@ptr)
-#     @ptr.setHeaderView(header)
-#     @ptr.addPtrUIHandler(header)
-#     @ptr.ptrHandler = PTRHandler.new do |frame|
-#       on_refresh if respond_to?(:on_refresh)
-#     end
-#   end
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
 
-#   def self.refreshable(params = {})
-#     @refreshable_params = params
-#     @refreshable = true
-#   end
+  module ClassMethods
+    def refreshable(params = {})
+      @refreshable_params = params
+      @refreshable = true
+    end
 
-#   def self.get_refreshable
-#     @refreshable ||= false
-#   end
+    def get_refreshable
+      @refreshable ||= false
+    end
 
-#   def self.get_refreshable_params
-#     @refreshable_params ||= nil
-#   end
+    def get_refreshable_params
+      @refreshable_params ||= nil
+    end
+  end
 
-#   def stop_refreshing
-#     @ptr.refreshComplete
-#   end
+  def make_refreshable(params={})
+    @ptr = find!(In::Srain::Cube::Views::Ptr::PtrFrameLayout)
+    header = In::Srain::Cube::Views::Ptr::Header::MaterialHeader.new(app.context)
+    ptr_colors = params[:color_array] || [color.dark_gray]
+    header.setColorSchemeColors(ptr_colors)
+    header.setPtrFrameLayout(@ptr)
+    @ptr.setHeaderView(header)
+    @ptr.addPtrUIHandler(header)
+    @ptr.ptrHandler = PTRHandler.new do |frame|
+      on_refresh if respond_to?(:on_refresh)
+    end
+  end
+
+  def stop_refreshing
+    @ptr.refreshComplete
+  end
 
 end

--- a/lib/project/pro_motion/fragments/refreshable_list.rb
+++ b/lib/project/pro_motion/fragments/refreshable_list.rb
@@ -1,0 +1,35 @@
+# SHould be included in PMListScreen but RMA is acting up
+module RefreshableList
+
+  def make_refreshable(params={})
+    @ptr = find!(In::Srain::Cube::Views::Ptr::PtrFrameLayout)
+    header = In::Srain::Cube::Views::Ptr::Header::MaterialHeader.new(app.context)
+    ptr_colors = params[:color_array] || [color.dark_gray]
+    header.setColorSchemeColors(ptr_colors)
+    header.setPtrFrameLayout(@ptr)
+    @ptr.setHeaderView(header)
+    @ptr.addPtrUIHandler(header)
+    @ptr.ptrHandler = PtrHandler.new do |frame|
+      # should call on_refresh if respond_to?(:on_refresh)
+      frame.refreshComplete
+    end
+  end
+
+  def self.refreshable(params = {})
+    @refreshable_params = params
+    @refreshable = true
+  end
+
+  def self.get_refreshable
+    @refreshable ||= false
+  end
+
+  def self.get_refreshable_params
+    @refreshable_params ||= nil
+  end
+
+  def stop_refreshing
+    @ptr.refreshComplete
+  end
+
+end

--- a/lib/project/pro_motion/fragments/refreshable_list.rb
+++ b/lib/project/pro_motion/fragments/refreshable_list.rb
@@ -1,35 +1,34 @@
-# SHould be included in PMListScreen but RMA is acting up
+# # Should be included in PMListScreen but RMA is acting up
 module RefreshableList
 
-  def make_refreshable(params={})
-    @ptr = find!(In::Srain::Cube::Views::Ptr::PtrFrameLayout)
-    header = In::Srain::Cube::Views::Ptr::Header::MaterialHeader.new(app.context)
-    ptr_colors = params[:color_array] || [color.dark_gray]
-    header.setColorSchemeColors(ptr_colors)
-    header.setPtrFrameLayout(@ptr)
-    @ptr.setHeaderView(header)
-    @ptr.addPtrUIHandler(header)
-    @ptr.ptrHandler = PtrHandler.new do |frame|
-      # should call on_refresh if respond_to?(:on_refresh)
-      frame.refreshComplete
-    end
-  end
+#   def make_refreshable(params={})
+#     @ptr = find!(In::Srain::Cube::Views::Ptr::PtrFrameLayout)
+#     header = In::Srain::Cube::Views::Ptr::Header::MaterialHeader.new(app.context)
+#     ptr_colors = params[:color_array] || [color.dark_gray]
+#     header.setColorSchemeColors(ptr_colors)
+#     header.setPtrFrameLayout(@ptr)
+#     @ptr.setHeaderView(header)
+#     @ptr.addPtrUIHandler(header)
+#     @ptr.ptrHandler = PTRHandler.new do |frame|
+#       on_refresh if respond_to?(:on_refresh)
+#     end
+#   end
 
-  def self.refreshable(params = {})
-    @refreshable_params = params
-    @refreshable = true
-  end
+#   def self.refreshable(params = {})
+#     @refreshable_params = params
+#     @refreshable = true
+#   end
 
-  def self.get_refreshable
-    @refreshable ||= false
-  end
+#   def self.get_refreshable
+#     @refreshable ||= false
+#   end
 
-  def self.get_refreshable_params
-    @refreshable_params ||= nil
-  end
+#   def self.get_refreshable_params
+#     @refreshable_params ||= nil
+#   end
 
-  def stop_refreshing
-    @ptr.refreshComplete
-  end
+#   def stop_refreshing
+#     @ptr.refreshComplete
+#   end
 
 end

--- a/lib/project/ruby_motion_query/rmq/event_wrappers/ptr_handler.rb
+++ b/lib/project/ruby_motion_query/rmq/event_wrappers/ptr_handler.rb
@@ -1,10 +1,10 @@
-class PtrHandler
+class PTRHandler
   def initialize(&block)
     @refresh_callback = block
   end
 
   def checkCanDoRefresh(frame, content, header)
-    true
+    !content.canScrollVertically(-1)
   end
 
   def onRefreshBegin(frame)

--- a/lib/project/ruby_motion_query/rmq/event_wrappers/ptr_handler.rb
+++ b/lib/project/ruby_motion_query/rmq/event_wrappers/ptr_handler.rb
@@ -1,0 +1,13 @@
+class PtrHandler
+  def initialize(&block)
+    @refresh_callback = block
+  end
+
+  def checkCanDoRefresh(frame, content, header)
+    true
+  end
+
+  def onRefreshBegin(frame)
+    @refresh_callback.call(frame)
+  end
+end

--- a/resources/layout/embedded_listview.xml
+++ b/resources/layout/embedded_listview.xml
@@ -9,11 +9,26 @@
         android:layout_height="wrap_content"
         android:id="@+id/textView" />
 
+    <in.srain.cube.views.ptr.PtrFrameLayout
+        android:id="@+id/store_house_ptr_frame"
+        xmlns:cube_ptr="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
 
-    <ListView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/some_internal_listview"
-        android:layout_below="@+id/textView" />
+        cube_ptr:ptr_resistance="1.7"
+        cube_ptr:ptr_ratio_of_header_height_to_refresh="1.2"
+        cube_ptr:ptr_duration_to_close="300"
+        cube_ptr:ptr_duration_to_close_header="2000"
+        cube_ptr:ptr_keep_header_when_refresh="true"
+        cube_ptr:ptr_pull_to_fresh="false" >
+
+
+        <ListView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/some_internal_listview"
+            android:layout_below="@+id/textView" />
+
+    </in.srain.cube.views.ptr.PtrFrameLayout>
 
 </RelativeLayout>

--- a/resources/layout/embedded_listview.xml
+++ b/resources/layout/embedded_listview.xml
@@ -10,7 +10,8 @@
        android:textAppearance="?android:attr/textAppearanceLarge"
        android:text="I'm not part of the listview!  I'm just hanging out."
        android:id="@+id/text_view"
-       android:layout_marginLeft="10dp"
+       android:paddingLeft="10dp"
+       android:background="#AFAFAF"
        android:gravity="center_vertical" />
 
     <in.srain.cube.views.ptr.PtrClassicFrameLayout

--- a/resources/layout/embedded_listview.xml
+++ b/resources/layout/embedded_listview.xml
@@ -1,34 +1,29 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin" tools:context=".MainActivityFragment">
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+   android:orientation="vertical" android:layout_width="match_parent"
+   android:layout_height="match_parent"
+   android:id="@+id/root_view">
 
-    <TextView android:text="I'm not part of the listview!  I'm just hanging out." android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/textView" />
+   <TextView
+       android:layout_width="match_parent"
+       android:layout_height="50dp"
+       android:textAppearance="?android:attr/textAppearanceLarge"
+       android:text="I'm not part of the listview!  I'm just hanging out."
+       android:id="@+id/text_view"
+       android:layout_marginLeft="10dp"
+       android:gravity="center_vertical" />
 
-    <in.srain.cube.views.ptr.PtrFrameLayout
+    <in.srain.cube.views.ptr.PtrClassicFrameLayout
         android:id="@+id/store_house_ptr_frame"
         xmlns:cube_ptr="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="match_parent">
 
-        cube_ptr:ptr_resistance="1.7"
-        cube_ptr:ptr_ratio_of_header_height_to_refresh="1.2"
-        cube_ptr:ptr_duration_to_close="300"
-        cube_ptr:ptr_duration_to_close_header="2000"
-        cube_ptr:ptr_keep_header_when_refresh="true"
-        cube_ptr:ptr_pull_to_fresh="false" >
+       <ListView
+           android:layout_width="match_parent"
+           android:layout_height="wrap_content"
+           android:id="@+id/list_view"
+           android:layout_gravity="center_horizontal" />
 
-
-        <ListView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/some_internal_listview"
-            android:layout_below="@+id/textView" />
-
-    </in.srain.cube.views.ptr.PtrFrameLayout>
-
-</RelativeLayout>
+    </in.srain.cube.views.ptr.PtrClassicFrameLayout>
+</LinearLayout>


### PR DESCRIPTION
The code is a lot like iOS.   Just add `refreshable` to the class, and use `on_refresh` and `stop_refreshing`.   This requires the ultra pull to refresh gradle

```ruby
    # pull to refresh
    dependency 'in.srain.cube:ultra-ptr:1.0.10'
```

### Caveat:
Wrap your listview in the XML tag to identify what is Pull to Refresh
```xml
    <in.srain.cube.views.ptr.PtrClassicFrameLayout
        android:id="@+id/store_house_ptr_frame"
        xmlns:cube_ptr="http://schemas.android.com/apk/res-auto"
        android:layout_width="match_parent"
        android:layout_height="match_parent">

       <ListView
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:id="@+id/list_view"
           android:layout_gravity="center_horizontal" />

    </in.srain.cube.views.ptr.PtrClassicFrameLayout>
```

I'd love to remove this, so listviews are automatically wrapped, but that's a bit outside our needs right now.

Special thanks to @markrickert who answered some amazing questions about `refreshable` on ProMotion, and @fvonhoven for moral support on XML woes :+1: 

### Example added to home application