### PR TITLE
Allows finding of the list view to be overridden.

### DIFF
--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -43,8 +43,12 @@
       add_adapter
     end
 
+    def find_list_view
+      find.activity.find(Potion::ListView)
+    end
+
     def add_adapter
-      found_listviews = find.activity.find(Potion::ListView)
+      found_listviews = find_list_view
       if found_listviews.count.zero?
         mp "PM ListView Error - We couldn't find any listviews on this screen."
       elsif found_listviews.count > 1


### PR DESCRIPTION
In case you have 2 ListViews on 1 Screen, here's another way to specify which one is driven by the adapter.  Override `find_list_view` and provide your own.