### PR TITLE
Adapter screen timing fix

### DIFF
--- a/lib/project/pro_motion/adapters/pm_base_adapter.rb
+++ b/lib/project/pro_motion/adapters/pm_base_adapter.rb
@@ -11,7 +11,7 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
     @screen ||= rmq.screen
   end
   def screen=(value)
-    @screen
+    @screen = value
   end
 
   def areAllItemsEnabled(); are_all_items_enabled?; end
@@ -79,7 +79,7 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
     if data[:action]
       find(out).on(:tap) do
         arguments = action_arguments data, position
-        find.screen.send(data[:action], arguments, position)
+        screen.send(data[:action], arguments, position)
       end
     end
     out
@@ -95,10 +95,10 @@ class PMBaseAdapter < Android::Widget::BaseAdapter
     if update.is_a?(Proc)
       update.call(out, data)
     elsif update.is_a?(Symbol) || update.is_a?(String)
-      if find.screen.respond_to?(update)
-        find.screen.send(update, view, data)
+      if screen.respond_to?(update)
+        screen.send(update, view, data)
       else
-        mp "Warning: #{find.screen.class} does not respond to #{update}"
+        mp "Warning: #{screen.class} does not respond to #{update}"
       end
     elsif data[:properties]
       data[:properties].each do |k, v|

--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -90,6 +90,12 @@
       @_extra_view_types ||= extra_types
     end
 
+    def on_destroy
+      return unless @adapter
+      @adapter.screen = nil
+      @adapter = nil
+    end
+
   end
 
 #end

--- a/lib/project/pro_motion/fragments/pm_list_screen.rb
+++ b/lib/project/pro_motion/fragments/pm_list_screen.rb
@@ -64,10 +64,11 @@
         if td.is_a?(Array)
           cells = td.first[:cells]
           # Pass data to adapter, and identify if dynamic data will be used, too.
-          PMBaseAdapter.new(data: cells, extra_view_types: self.class.extra_view_types)
+          PMBaseAdapter.new(data: cells, extra_view_types: self.class.extra_view_types).tap { |a| a.screen = self }
+
         elsif td.is_a?(Hash)
           mp "Please supply a cursor in #{self.inspect}#table_data." unless td[:cursor]
-          PMCursorAdapter.new(td)
+          PMCursorAdapter.new(td).tap { |a| a.screen = self }
         end
       end
     end


### PR DESCRIPTION
An adapter can start requesting data from it's list screen prior to blue potion setting the proper PMScreen on `find.screen`.

This tells the adapter explicitly who the parent screen is, so we're not firing off update methods against the "last" screen.

Another option might be to start the adapter in a paused state so the data doesn't flow until `find.screen` is the right one.   
