### PR TITLE
Allow array as param

### DIFF
--- a/lib/project/volley_wrap/request.rb
+++ b/lib/project/volley_wrap/request.rb
@@ -87,6 +87,10 @@ module VW
           params[key].keys.each do |inner_key|
             new_params["#{key}[#{inner_key}]"] = params[key][inner_key].to_s
           end
+        elsif params[key].is_a?(Array)
+          params[key].each_with_index do |value, index|
+            new_params["#{key}[#{index}]"] = value.to_s
+          end
         else
           new_params[key.to_s] = params[key].to_s
         end


### PR DESCRIPTION
Let's say I want to request a page with an array of ids. 
The params should be something like `url?id[]=1&id[]=2` or `url?id[0]=1&id[1]=2`

This PR allows the use of `Array` in params and `prepare_params` to fit this array notation

The use will be 
```ruby
app.net.post(SomeUrl, { ids: [1, 2] }) 
```