### PR TITLE
Add a progressbar to ProgressHUD

### DIFF
--- a/lib/project/progress_hud/progress_hud.rb
+++ b/lib/project/progress_hud/progress_hud.rb
@@ -6,8 +6,10 @@
 
 class ProgressHUD < Android::App::DialogFragment
 
-  def initialize(title="Loading")
+  def initialize(title="Loading", opts={})
     @title = title
+    @style = convert_style(opts[:style])
+    @max = opts[:max]
   end
 
   def show(activity=rmq.activity)
@@ -18,12 +20,36 @@ class ProgressHUD < Android::App::DialogFragment
     builder = Android::App::AlertDialog::Builder.new(activity,
       Android::App::AlertDialog::THEME_HOLO_LIGHT)
 
-    progress = Android::Widget::ProgressBar.new(activity)
-    progress.setBackgroundColor(Android::Graphics::Color::TRANSPARENT)
-    builder.setView(progress)
-           .setTitle(@title)
+    if @style
+      @progress = Android::Widget::ProgressBar.new(activity, nil, @style)
+      if @max
+        @progress.setIndeterminate(false)
+        @progress.setMax(@max)
+      end
+    else
+      @progress = Android::Widget::ProgressBar.new(activity)
+    end
+    @progress.setBackgroundColor(Android::Graphics::Color::TRANSPARENT)
+    builder.setView(@progress)
+        .setTitle(@title)
 
     @created_dialog = builder.create()
+  end
+
+  def progress=(value)
+    @progress.setProgress(value)
+  end
+
+  def increment(inc=1)
+    runnable = HudRun.new
+    @current_progress ||= 0
+    @current_progress += inc
+    runnable.progress = @current_progress
+    runnable.hud = self
+
+    # 99.99% of the time, we will use this from within app.async
+    # so we need to be sure to run the progress in the UI thread
+    activity.runOnUiThread(runnable)
   end
 
   def title=(new_title)
@@ -34,5 +60,26 @@ class ProgressHUD < Android::App::DialogFragment
     self.dismiss
   end
   alias_method :close, :hide
+
+  protected
+  def convert_style(style)
+    return nil if style.nil?
+
+    case style
+      when :horizontal
+        Android::R::Attr::ProgressBarStyleHorizontal
+      else
+        style
+    end
+  end
+
+end
+
+class HudRun
+  attr_accessor :hud, :progress
+
+  def run
+    hud.progress = progress
+  end
 
 end


### PR DESCRIPTION
This PR adds the possibility to set a `max` attribute on a new `ProgressHUD` and then use `hud.increment` to set the progress

The following video came from this example
```ruby
find(R::Id::Progress).on(:tap) do |_|
  @hud = ProgressHUD.new('Loading', style: :horizontal, max: 100)
  @hud.show
  app.async do
    (0..100).each do |_|
      @hud.increment
      sleep 0.2
    end
  end.on(:completion) do |_|
    @hud.dismiss
  end
end

```

You can also use `increment(some_value)`

[![BP ProgressHUD ](http://img.youtube.com/vi/dS24XN1LhL8/0.jpg)](http://www.youtube.com/watch?v=dS24XN1LhL8)

This PR also complete #16