### PR TITLE
PotionDateTimePicker

### DIFF
--- a/lib/project/date_dialog/potion_date_time_picker.rb
+++ b/lib/project/date_dialog/potion_date_time_picker.rb
@@ -1,0 +1,32 @@
+class PotionDateTimePicker
+
+  def initialize(opts={}, &block)
+    @date = opts.fetch(:date, Time.new)
+    @is_date = opts.fetch(:type, :date) == :date
+    @hour_of_day = opts.fetch(:hour, 0)
+    @minute = opts.fetch(:minute, 0)
+    @is_24_hour = opts.fetch(:is_24_hour, true)
+
+    @completion = block
+    setup
+  end
+
+  def setup
+    if @is_date
+      year = @date.strftime('%Y').to_i # TODO bug RM or BP ?
+      month = @date.month
+      day = @date.date
+
+      @dialog = Android::App::DatePickerDialog.new(find.activity,
+                                                   RMQDateListener.new(&@completion),
+                                                   year, month, day)
+    else
+      @dialog = Android::App::TimePickerDialog.new(find.activity,
+                                                   RMQTimeListener.new(&@completion),
+                                                   @hour_of_day, @minute, @is_24_hour)
+    end
+    @dialog.show
+    @dialog
+  end
+
+end

--- a/lib/project/date_dialog/potion_date_time_picker.rb
+++ b/lib/project/date_dialog/potion_date_time_picker.rb
@@ -1,5 +1,9 @@
 class PotionDateTimePicker
 
+  def self.show(opts={}, &block)
+    picker = PotionDateTimePicker.new(opts, &block)
+  end
+
   def initialize(opts={}, &block)
     @date = opts.fetch(:date, Time.new)
     @is_date = opts.fetch(:type, :date) == :date

--- a/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_date_listener.rb
+++ b/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_date_listener.rb
@@ -1,0 +1,14 @@
+class RMQDateListener
+
+  def initialize(&block)
+    @block = block
+  end
+
+  def onDateSet(view, year, month_of_year, day_of_month)
+    # TODO bug RM or BP ?
+    #time = Time.new(year, month_of_year, day_of_month)
+    #mp time.inspect
+    time = Time.from_string("#{day_of_month}/#{month_of_year + 1}/#{year}")
+    @block.call(time) if @block
+  end
+end

--- a/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_time_listener.rb
+++ b/lib/project/ruby_motion_query/rmq/event_wrappers/rmq_time_listener.rb
@@ -1,0 +1,10 @@
+class RMQTimeListener
+
+  def initialize(&block)
+    @block = block
+  end
+
+  def onTimeSet(view,  hour_of_day, minute)
+    @block.call(hour_of_day, minute) if @block
+  end
+end

--- a/lib/project/ruby_motion_query/rmq/events.rb
+++ b/lib/project/ruby_motion_query/rmq/events.rb
@@ -42,6 +42,10 @@ class RMQ
       view.addTextChangedListener(RMQTextChange.new(&block))
     elsif view.respond_to? :setOnValueChangedListener
       view.onValueChangedListener = RMQNumberPickerChange.new(&block)
+    elsif view.respond_to? :setOnDateChanged
+      view.onDateChanged = RMQDateListener.new(&block)
+    elsif view.respond_to? :setOnTimeChanged
+      view.onTimeChanged = RMQTimeListener.new(&block)
     end
   end
 


### PR DESCRIPTION
This PR adds DatePicker and TimePicker

```ruby
# show datepicker
PotionDateTimePicker.new do |time|
  mp time.to_s
end
```

```ruby
# show timepicker
PotionDateTimePicker.new(type: :time) do |hour, minute|
  mp "#{hour}:#{minute}"
end
```

There are few options like `:time`, `:hour`, ...
