### PR TITLE
Call on_back_pressed

### DIFF
--- a/lib/project/pro_motion/activities/pm_activity.rb
+++ b/lib/project/pro_motion/activities/pm_activity.rb
@@ -79,6 +79,9 @@
     end
 
     def onBackPressed
+      if find.screen.respond_to? :on_back_pressed
+        find.screen.on_back_pressed
+      end
       return if find.screen.class.allow_back_button == false
       super
       finish if fragmentManager.getBackStackEntryCount == 0


### PR DESCRIPTION
This PR allows adding a `on_back_pressed` on a `Screen`. 
This method will be called (if exists ofc) by `PMActivity#onBackPressed`.