### PR TITLE
Fix PMHashBundle type checking for recent RubyMotion versions

### DIFF
--- a/lib/project/pro_motion/support/pm_hash_bundle.rb
+++ b/lib/project/pro_motion/support/pm_hash_bundle.rb
@@ -28,15 +28,15 @@ class PMHashBundle
         value_type = value_types[i]
 
         value = case value_type
-        when "com.rubymotion.String"
+        when "com.rubymotion.String", "String"
           bundle.getString(key)
-        when "com.rubymotion.Symbol"
+        when "com.rubymotion.Symbol", "Symbol"
           bundle.getString(key).to_sym
-        when "java.lang.Integer"
+        when "java.lang.Integer", "Integer"
           bundle.getInt(key)
-        when "java.lang.Double"
+        when "java.lang.Double", "Double"
           bundle.getFloat(key)
-        when "java.util.ArrayList"
+        when "java.util.ArrayList", "ArrayList"
           bundle.getStringArrayList(key)
           # TODO, do more types
         else
@@ -64,15 +64,15 @@ class PMHashBundle
         value = values[i]
 
         case value_type
-        when "com.rubymotion.String"
+        when "com.rubymotion.String", "String"
           bundle.putString(key, value)
-        when "com.rubymotion.Symbol"
+        when "com.rubymotion.Symbol", "Symbol"
           bundle.putString(key, value.to_s)
-        when "java.lang.Integer"
+        when "java.lang.Integer", "Integer"
           bundle.putInt(key, value)
-        when "java.lang.Double"
+        when "java.lang.Double", "Double"
           bundle.putFloat(key, value)
-        when "java.util.ArrayList"
+        when "java.util.ArrayList", "ArrayList"
           value = value.map{|o| o.to_s}
           bundle.putStringArrayList(key, value)
         # TODO, do more types


### PR DESCRIPTION
Newer versions of RubyMotion return short strings (e.g. `String`, `Symbol`) for class names in Java/Android. I've updated the type checking in `PMHashBundle` to add the shorter class names. Previously these shorter names were falling through the `when` conditions to cause "invalid type" exceptions.